### PR TITLE
Launching middleware required in testing with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For example, with below comand. ( Set `$TOMCAT_DIR` environment value to path of
 1. Execute tests with maven.
 
     ```
-    mvn -f pom.xml
+    mvn -f pom.xml test
     ```
 
 ## Build and setup

--- a/README.md
+++ b/README.md
@@ -29,9 +29,18 @@ limitations under the License.
 
 1. Place `personium-ex-mailsender` jar file and `Ext_MailSender.properties` file in `/personium/personium-engine/`
 1. Launch required software with `docker-compose up`
-1. Launch tomcat9 locally
-1. Deploy `personium-core` tomcat locally with option `io.personium.core.pathBasedCellUrl.enabled=true`
+1. Launch `personium-core` on Tomcat9 locally.  
+For example, with below comand. ( Set `$TOMCAT_DIR` environment value to path of directory which Tomcat9 installed, and place `personium-core.war` on `$TOMCAT_DIR/webapps/personium-core.war`. )
+
+    ```
+    JAVA_OPTS="-Djava.util.logging.config.file=$TOMCAT_DIR/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Dcatalina.base=$TOMCAT_DIR -Dcatalina.home=$TOMCAT_DIR -Djava.io.tmpdir=$TOMCAT_DIR/temp -Dio.personium.configurationFile=$PWD/src/test/resources/personium-core-unit-config.properties" catalina.sh run
+    ```
+
 1. Execute tests with maven.
+
+    ```
+    mvn -f pom.xml
+    ```
 
 ## Build and setup
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ limitations under the License.
 ## Testing
 
 1. Place `personium-ex-mailsender` jar file and `Ext_MailSender.properties` file in `/personium/personium-engine/`
-1. Launch prequire software with `docker-compose up`
+1. Launch required software with `docker-compose up`
 1. Launch tomcat9 locally
 1. Deploy `personium-core` tomcat locally with option `io.personium.core.pathBasedCellUrl.enabled=true`
 1. Execute tests with maven.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+## Testing
+
+1. Place `personium-ex-mailsender` jar file and `Ext_MailSender.properties` file in `/personium/personium-engine/`
+1. Launch prequire software with `docker-compose up`
+1. Launch tomcat9 locally
+1. Deploy `personium-core` tomcat locally with option `io.personium.core.pathBasedCellUrl.enabled=true`
+1. Execute tests with maven.
+
 ## Build and setup
 
 1. Use maven to build personium-engine.war file to run on a servlet container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.7"
+
+services:
+  elasticsearch:
+    image: elasticsearch:6.8.12
+    ports:
+      - 9200:9200
+      - 9300:9300
+    environment:
+      - "discovery.type=single-node"
+      - "cluster.name=personium"
+      - "network.host=0.0.0.0"
+      - "action.auto_create_index=.watches,.triggered_watches,.watcher-history-*"
+      - "http.cors.enabled=true"
+      - "http.cors.allow-origin=*"
+      - "indices.fielddata.cache.size=80%"
+  activemq:
+    image: rmohr/activemq:5.15.9
+    ports:
+      - 61616:61616
+      - 8161:8161
+  memcached-lock:
+    image: memcached:1.6.7
+    ports:
+      - 11211:11211
+
+  memcached-cache:
+    image: memcached:1.6.7
+    ports:
+      - 11212:11211
+
+  nginx:
+    build:
+      context: ./dockerfiles/nginx
+    ports:
+      - 80:80
+    extra_hosts:
+      - "host.docker.internal:172.101.0.1"
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.101.0.0/16

--- a/dockerfiles/nginx/Dockerfile
+++ b/dockerfiles/nginx/Dockerfile
@@ -1,0 +1,16 @@
+FROM nginx:1.14
+
+RUN apt-get update && apt-get install -y \
+  vim \
+  curl \
+  jq
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+COPY conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /
+
+EXPOSE 443
+EXPOSE 80
+
+# ENTRYPOINT [ "/entrypoint.sh" ]

--- a/dockerfiles/nginx/conf.d/default.conf
+++ b/dockerfiles/nginx/conf.d/default.conf
@@ -1,0 +1,65 @@
+server {
+    listen       80;
+    server_name  personium;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+            if ($request_uri ~ [\x00-\x20\x22\x3c\x3e\x5b-\x5e\x60\x7b-\x7d\x7f]) {
+                return 400;
+            }
+
+            if ($request_uri ~* ([^?]+)\?(.*)) {
+              set $personium_path $1;
+              rewrite .* /personium-core$personium_path break;
+            }
+            if ($is_args = "") {
+              rewrite .* /personium-core$request_uri break;
+            }
+
+            proxy_pass http://host.docker.internal:8080;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto http;
+            proxy_set_header X-Forwarded-Path $request_uri;
+            proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_hide_header X-Powered-By;
+            proxy_hide_header X-Rack-Cache;
+            proxy_hide_header X-Content-Digest;
+            proxy_hide_header X-Runtime;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/dockerfiles/nginx/entrypoint.sh
+++ b/dockerfiles/nginx/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+PERSONIUM_URL=localhost:8080/personium-core
+
+for i in {1..30}; do
+  RESULT=$(curl --silent --fail ${PERSONIUM_URL})
+  if [ $? -eq 0 ]; then
+    >&2 echo "Personium is ready"
+    >&2 echo ${RESULT} | jq .
+    exit 0
+  else
+    >&2 echo "Personium is not ready (${i}): ${RESULT}"
+    sleep 10
+  fi
+done
+
+>&2 echo "Elastic search is unavailable - Timeout"
+exit 1

--- a/dockerfiles/nginx/nginx.conf
+++ b/dockerfiles/nginx/nginx.conf
@@ -1,0 +1,43 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main; 
+ 
+    sendfile        on; 
+    #tcp_nopush     on; 
+ 
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    # For Personium configurations
+    ignore_invalid_headers on;
+    proxy_set_header Host $http_host;
+    proxy_http_version 1.1;
+    large_client_header_buffers 4 55k;
+
+    map $http_upgrade $connection_upgrade {
+      default upgrade;
+      '' close;
+    }
+}

--- a/src/test/resources/personium-core-unit-config.properties
+++ b/src/test/resources/personium-core-unit-config.properties
@@ -1,0 +1,205 @@
+#
+# Personium
+# Copyright 2019 Personium Project
+#  - FUJITSU LIMITED
+#  - (Add Authorss here)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#################################################
+# personium-core default configurations
+#
+# DO NOT CHANGE THE CONTENTS OF THIS FILE BELOW.
+# USE "personium-unit-config.properties" TO CHANGE CONFIGURATIONS.
+#################################################
+
+# core version
+io.personium.core.version=1.7.22
+
+# thread pool num.
+io.personium.core.thread.pool.num.io.cell=10
+io.personium.core.thread.pool.num.io.box=20
+io.personium.core.thread.pool.num.misc=20
+
+# general configurations
+io.personium.core.unitUser.issuers=
+io.personium.core.unitScheme=http
+# io.personium.core.unitPort=
+io.personium.core.pathBasedCellUrl.enabled=true
+
+# plugin
+io.personium.core.plugin.path=/personium/personium-core/plugins
+
+# engine configurations
+io.personium.core.engine.host=localhost
+io.personium.core.engine.port=9998
+io.personium.core.engine.path=
+
+# cell GUI configurations
+#io.personium.core.cell.relayhtmlurl.default=https://demo.personium.io/app-cc-home/__/index.html
+#io.personium.core.cell.authorizationhtmlurl.default=
+#io.personium.core.cell.authorizationpasswordchangehtmlurl.default=
+
+# lock general configurations (set milliseconds)
+io.personium.core.lock.retry.times=50
+io.personium.core.lock.retry.interval=100
+io.personium.core.lock.cell.retry.times=50
+io.personium.core.lock.cell.retry.interval=100
+
+# lock type configurations
+io.personium.core.lock.type=memcached
+io.personium.core.lock.memcached.host=localhost
+io.personium.core.lock.memcached.port=11211
+io.personium.core.lock.memcached.opTimeout=12000
+
+# authentication configurations
+io.personium.core.authn.account.lockCount=0
+io.personium.core.authn.account.lockTime=0
+io.personium.core.authn.account.validAuthnInterval=1
+
+# cache configurations (memcached protocol)
+io.personium.core.cache.type=memcached
+io.personium.core.cache.memcached.host=localhost
+io.personium.core.cache.memcached.port=11212
+io.personium.core.cache.memcached.opTimeout=12000
+io.personium.core.cache.memcached.expiresin=86400
+io.personium.core.cache.cell.enabled=true
+io.personium.core.cache.box.enabled=false
+io.personium.core.cache.schema.enabled=false
+
+# File Data Store configurations
+io.personium.core.binaryData.physical.delete.mode=true
+io.personium.core.binaryData.fsync.enabled=false
+io.personium.core.binaryData.dav.retry.count=100
+io.personium.core.binaryData.dav.retry.interval=50
+# blob store configurations
+io.personium.core.blobStore.root=/personium_nfs/personium-core/dav
+
+# Elasticsearch configurations
+io.personium.core.es.hosts=localhost:9300
+io.personium.core.es.cluster.name=personium
+io.personium.core.es.unitPrefix=u0
+io.personium.core.es.topnum=10000
+io.personium.core.es.retryTimes=3
+io.personium.core.es.retryInterval=1500
+## for elasticsearch v5.x or later.
+io.personium.core.es.index.numberOfShards=10
+io.personium.core.es.index.numberOfReplicas=0
+io.personium.core.es.index.maxResultWindow=150000
+#io.personium.core.es.index.merge.scheduler.maxThreadCount=
+
+# Security configurations
+io.personium.core.masterToken=
+io.personium.core.security.auth.password.regex=^[a-zA-Z0-9-_!$*=^`{|}~.@]{6,32}$
+io.personium.core.security.auth.password.hashAlgorithm=scrypt
+io.personium.core.security.auth.password.scrypt.cpuCost=16384
+io.personium.core.security.auth.password.scrypt.memoryCost=8
+io.personium.core.security.auth.password.scrypt.parallelization=1
+io.personium.core.security.auth.password.scrypt.keyLength=32
+io.personium.core.security.auth.password.scrypt.saltLength=64
+#io.personium.core.security.secret16=changeme
+#io.personium.core.security.auth.password.salt=changeme
+io.personium.core.security.dav.encrypt.enabled=false
+
+# Default token scope for various grant types
+#  "root" scope will be given as default for compatibility reason.
+#  Change these settings to make your unit more secure
+io.personium.core.security.token.defaultScope.ropc=root
+io.personium.core.security.token.defaultScope.assertion=root
+io.personium.core.security.token.defaultScope.grant_code=root
+
+
+# X509 Certificate file in PEM format
+# io.personium.core.x509.crt=/opt/x509/localhost.crt
+# X509 RSA PrivateKey file in PEM format
+# io.personium.core.x509.key=/opt/x509/localhost.key
+# X509 Root certificate file in PEM format
+# io.personium.core.x509.root=/opt/x509/personium_ca.crt
+
+# OData $batch configurations
+io.personium.core.odata.batch.bulkRequestMaxSize=1000
+io.personium.core.odata.batch.timeoutInMillis=270000
+io.personium.core.odata.batch.sleepInMillis=50
+io.personium.core.odata.batch.sleepIntervalInMillis=1000
+
+# OData $links configurations
+io.personium.core.odata.links.NtoN.maxnum=150000
+
+# OData $expand configurations
+io.personium.core.odata.expand.list.maxnum=100
+io.personium.core.odata.expand.retrieve.maxnum=1000
+
+# OData Query configurations
+io.personium.core.odata.query.top.maxnum=10000
+io.personium.core.odata.query.skip.maxnum=100000
+io.personium.core.odata.query.top.default=25
+io.personium.core.odata.query.expand.top.maxnum=100
+io.personium.core.odata.query.expand.property.maxnum.list=2
+io.personium.core.odata.query.expand.property.maxnum.retrieve=10
+
+# Property number limitation for userdata.
+io.personium.core.box.odata.schema.MaxEntityTypes=100
+io.personium.core.box.odata.schema.MaxProperties=400
+io.personium.core.box.odata.schema.property.LayerLimits.SimpleType=*,50,30,10
+io.personium.core.box.odata.schema.property.LayerLimits.ComplexType=20,5,2,0
+
+# Davlimit configrations
+io.personium.core.dav.childresource.maxnum=1024
+io.personium.core.dav.depth.maxnum=50
+
+# bar file export/install
+io.personium.core.bar.file.maxSize=100
+io.personium.core.bar.entry.maxSize=10
+io.personium.core.bar.userdata.linksOutputStreamSize=5
+io.personium.core.bar.userdata.bulkSize=1000
+io.personium.core.bar.tmp.dir=/personium_nfs/personium-core/bar
+io.personium.core.bar.progress.expireInSec=259200
+
+# event log file directory
+io.personium.core.event.log.current.dir=/personium_nfs/personium-core/eventlog
+# event hop limitation
+io.personium.core.event.hop.maxnum=3
+
+# OpenID Connect Configrations
+io.personium.core.oidc.google.trustedClientIds=*
+
+# cell export configurations
+io.personium.core.cellSnapshot.root=/personium_nfs/personium-core/snapshot
+
+# EventBus configurations
+io.personium.core.eventbus.mq=activemq
+io.personium.core.eventbus.broker=tcp://localhost:61616
+io.personium.core.eventbus.queue=personium_event_queue
+io.personium.core.eventbus.topic.all=personium_event_topic
+io.personium.core.eventbus.topic.rule=personium_event_topic_rule
+io.personium.core.eventbus.eventProcessing.thread.num=1
+
+# stream configurations
+io.personium.core.stream.mq=
+#io.personium.core.stream.broker=
+#io.personium.core.stream.username=
+#io.personium.core.stream.password=
+# data retention period in sec
+io.personium.core.stream.expiresIn=3600
+
+# rule configurations
+io.personium.core.rule.timerEvent.thread.num=1
+
+# Token Introspection configurations
+#io.personium.core.introspect.username=
+#io.personium.core.introspect.password=
+
+io.personium.core.security.secret16=gv7hpmmf5siwj5by
+io.personium.core.lock.type=inProcess
+io.personium.core.masterToken=personiumio


### PR DESCRIPTION

There are middleware needed to run test of `personium-engine`

- ElasticSearch
- ActiveMQ
- memcached
- nginx
- Tomcat

I write docker-compose to launch them excepting Tomcat.
( You need launch Tomcat locally and deploy `personium-core` there )

How about this?