### PR TITLE
modify codes for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ docker run -d -p 8080:8080 -v /path/to/config.properties:/personium/personium-en
 
 ## Testing
 
-1. Place `personium-ex-mailsender` jar file and `Ext_MailSender.properties` file in `/personium/personium-engine/`
+1. Place `personium-ex-mailsender` jar file and `Ext_MailSender.properties` file in `/personium/personium-engine/extensions`. Content of `Ext_MailSender.properties` is below.  
+    ```properties
+    io.personium.engine.extension.MailSender.smtp.host=localhost
+    io.personium.engine.extension.MailSender.smtp.port=1025
+    ```
 1. Launch required software with `docker-compose up`
 1. Launch `personium-core` on Tomcat9 locally.  
 For example, with below comand. ( Set `$TOMCAT_DIR` environment value to path of directory which Tomcat9 installed, and place `personium-core.war` on `$TOMCAT_DIR/webapps/personium-core.war`. )

--- a/src/test/java/io/personium/jersey/engine/test/ScriptTestBase.java
+++ b/src/test/java/io/personium/jersey/engine/test/ScriptTestBase.java
@@ -23,8 +23,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
+
+import javax.ws.rs.core.UriBuilder;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -558,11 +559,6 @@ public abstract class ScriptTestBase extends JerseyTest {
      */
     @Override
     protected URI getBaseURI() {
-        try {
-            return new URI(this.jerseyBaseUrl);
-        } catch(URISyntaxException e) {
-            e.printStackTrace();
-            return null;
-        }
+        return UriBuilder.fromPath(jerseyBaseUrl).build();
     }
 }

--- a/src/test/java/io/personium/jersey/engine/test/ScriptTestBase.java
+++ b/src/test/java/io/personium/jersey/engine/test/ScriptTestBase.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.fail;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 
 import org.apache.http.HttpResponse;
@@ -54,6 +56,12 @@ import io.personium.engine.utils.PersoniumEngineConfig;
 public abstract class ScriptTestBase extends JerseyTest {
     /** ローカルテスト用EngineリクエストUrl. */
     public static final String LOCAL_TEST_SERVICE_URL = "http://localhost:9998";
+    /** Default Jersey base URL */
+    public static final String DEFAULT_JERSERY_BASE_URL = "http://localhost:9998";
+    /** Key for getting Jersey base URL */
+    public static final String PROP_JERSEY_BASE_URL = "io.personium.engine.jerseyTest.baseUrl";
+    /** Jersey base URL */
+    static String jerseyBaseUrl = System.getProperty(PROP_JERSEY_BASE_URL, DEFAULT_JERSERY_BASE_URL);
     /** デフォルトのリクエスト送信先URL. */
     public static final String DEFAULT_TARGET_URL = "http://localhost";
     /** リクエスト送信先URLを取得するプロパティのキー. */
@@ -544,4 +552,17 @@ public abstract class ScriptTestBase extends JerseyTest {
         return PersoniumEngineTestConfig.getVersion();
     }
 
+    /**
+     * Function for getting base Url
+     * @return URL which Grizzly starts listening
+     */
+    @Override
+    protected URI getBaseURI() {
+        try {
+            return new URI(this.jerseyBaseUrl);
+        } catch(URISyntaxException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/src/test/resources/personium-unit-config.properties
+++ b/src/test/resources/personium-unit-config.properties
@@ -5,3 +5,6 @@ io.personium.engine.testKey3=keyWithEnginePrefix
 
 io.personium.core.security.secret16=gv7hpmmf5siwj5by
 io.personium.core.masterToken=personiumio
+
+# blob store configurations (for system test)
+io.personium.core.blobStore.root=/personium_nfs/personium-core/dav


### PR DESCRIPTION
Modify codes for executing test.

1. Make you can use `io.personium.engine.jerseyTest.baseUrl` property.
2. Modify readme.
3. Adding default configuration of Dav folder for system test.